### PR TITLE
Added activation events for all existing commands.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,26 @@
     "Snippets"
   ],
   "activationEvents": [
+    "onLanguage:rust",
     "onCommand:rust.cargo.new.bin",
     "onCommand:rust.cargo.new.lib",
-    "onLanguage:rust"
+    "onCommand:rust.cargo.build.example.debug",
+    "onCommand:rust.cargo.build.example.release",
+    "onCommand:rust.cargo.run.example.debug",
+    "onCommand:rust.cargo.run.example.release",
+    "onCommand:rust.cargo.build.debug",
+    "onCommand:rust.cargo.build.release",
+    "onCommand:rust.cargo.run.debug",
+    "onCommand:rust.cargo.run.release",
+    "onCommand:rust.cargo.doc",
+    "onCommand:rust.cargo.test.debug",
+    "onCommand:rust.cargo.test.release",
+    "onCommand:rust.cargo.bench",
+    "onCommand:rust.cargo.update",
+    "onCommand:rust.cargo.clean",
+    "onCommand:rust.cargo.check",
+    "onCommand:rust.cargo.check.lib",
+    "onCommand:rust.cargo.terminate"
   ],
   "main": "./out/src/extension",
   "contributes": {


### PR DESCRIPTION
Following removal of plugin activation on TOML files, Cargo commands are no longer runnable if `cargo.toml` (or any other non-rs file) is opened before any Rust files.

I believe, that currently, the best way to solve this, is to list all RustyCode command contributions in `activationEvents`. There is a downside though- the `activationEvents` list will have to be updated every time when commands will be added or changed (at least for now: Microsoft/vscode#16045).