### PR TITLE
De-duplicate diagnostic messages in the problems panel.

### DIFF
--- a/src/services/commandService.ts
+++ b/src/services/commandService.ts
@@ -324,7 +324,7 @@ export class CommandService {
         });
 
         diagnosticMap.forEach((diags, uri) => {
-            this.diagnostics.set(vscode.Uri.file(uri), diags);
+            this.diagnostics.set(vscode.Uri.file(uri), distinctDiagnostics(diags));
         });
     }
 
@@ -682,4 +682,14 @@ function addNotesToMessage(msg: string, children: any[], level: number): string 
         }
     }
     return msg;
+}
+
+function distinctDiagnostics(diags: vscode.Diagnostic[]): vscode.Diagnostic[] {
+    let map: Map<string, vscode.Diagnostic> = new Map();
+    for (const diag of diags) {
+        const key = `${diag.range.start.line}:${diag.range.start.character}:` +
+            `${diag.range.end.line}:${diag.range.end.character}:${diag.message}`;
+        map.set(key, diag);
+    }
+    return Array.from(map.values());
 }


### PR DESCRIPTION
_Rebase of saviorisdead/RustyCode#220_

Currently, `clippy` is returning duplicate `rustc` warnings for projects that have executable (Manishearth/rust-clippy#1365), and RustyCode is displaying them twice in problems panel. 

This PR leaves only unique Cargo's diagnostic messages (comparing by range+text) for each source file.