### PR TITLE
Added `Cargo: Clippy` to the list of commands. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "onCommand:rust.cargo.clean",
     "onCommand:rust.cargo.check",
     "onCommand:rust.cargo.check.lib",
-    "onCommand:rust.cargo.terminate"
+    "onCommand:rust.cargo.terminate",
+    "onCommand:rust.cargo.clippy"
   ],
   "main": "./out/src/extension",
   "contributes": {
@@ -154,6 +155,11 @@
         "command": "rust.cargo.check.lib",
         "title": "Cargo: Check Library",
         "description": "Check the main library of the project for warnings and errors"
+      },
+      {
+        "command": "rust.cargo.clippy",
+        "title": "Cargo: Clippy",
+        "description": "Check project with clippy."
       },
       {
         "command": "rust.cargo.terminate",


### PR DESCRIPTION
_Rebase of saviorisdead/RustyCode#221_

In a big project `cargo clippy` may take up to several minutes to run. It is not viable to set as default linter in this case. But it is useful to have an ability to call `cargo clippy` manually whenever it is needed.

This is related to saviorisdead/RustyCode#145.

Discussed in #7.