### PR TITLE
Skipping hidden lines in doc examples

### DIFF
--- a/src/services/suggestService.ts
+++ b/src/services/suggestService.ts
@@ -277,7 +277,9 @@ export default class SuggestService {
                 }
 
                 if (codeBlock) {
-                    currentBlock.push(docLine.slice(extraIndent));
+                    if (!docLine.trim().startsWith('#')) {
+                        currentBlock.push(docLine.slice(extraIndent));
+                    }
                     continue;
                 }
 

--- a/src/services/suggestService.ts
+++ b/src/services/suggestService.ts
@@ -277,7 +277,7 @@ export default class SuggestService {
                 }
 
                 if (codeBlock) {
-                    if (!docLine.trim().startsWith('#')) {
+                    if (!docLine.trim().startsWith('# ')) {
                         currentBlock.push(docLine.slice(extraIndent));
                     }
                     continue;


### PR DESCRIPTION
As per the [Rust book](https://doc.rust-lang.org/book/documentation.html), lines in codeblocks in documentation comments starting with `#` are not rendered. I think they should be hidden in the docs hover too – code checks if line starts with `#` (and is a inside a code block) and skips this line.