### PR TITLE
Use SIGTERM to terminate cargo task

### DIFF
--- a/src/services/commandService.ts
+++ b/src/services/commandService.ts
@@ -184,7 +184,7 @@ class CargoTask {
     public kill(): Thenable<any> {
         return new Promise(resolve => {
             if (!this.interrupted && this.process) {
-                kill(this.process.pid, 'SIGINT', resolve);
+                kill(this.process.pid, 'SIGTERM', resolve);
 
                 this.interrupted = true;
             }


### PR DESCRIPTION
This fixes #23 on my Linux machine. Note that this fix is untested on other platforms.

Currently cargo ignores SIGINT. By sending SIGTERM instead, the desired behavior (cargo terminates) can be achieved.