### PR TITLE
Fix: remove extra backslashes included in snippets

### DIFF
--- a/snippets/rust.json
+++ b/snippets/rust.json
@@ -128,14 +128,14 @@
     "format": {
         "prefix": "format",
         "body": [
-            "format!(\"${1:{${2::?}}}\")"
+            "format!(\"${1}\")"
         ],
         "description": "format!(…)"
     },
     "format_args": {
         "prefix": "format_args",
         "body": [
-            "format_args!(\"${1:{${2::?}}}\")"
+            "format_args!(\"${1}\")"
         ],
         "description": "format_args!(…)"
     },
@@ -184,21 +184,21 @@
     "panic": {
         "prefix": "panic",
         "body": [
-            "panic!(\"${1:{${2::?}}}\");"
+            "panic!(\"${1}\");"
         ],
         "description": "panic!(…);"
     },
     "print": {
         "prefix": "print",
         "body": [
-            "print!(\"${1:\\{${2::?}\\}}\");"
+            "print!(\"${1}\");"
         ],
         "description": "print!(…);"
     },
     "println": {
         "prefix": "println",
         "body": [
-            "println!(\"${1:{${2::?}}}\");"
+            "println!(\"${1}\");"
         ],
         "description": "println!(…);"
     },
@@ -247,14 +247,14 @@
     "write": {
         "prefix": "write",
         "body": [
-            "write!(${1}, \"${2:\\{${3::?}\\}}\")"
+            "write!(${1}, \"${2}\")"
         ],
         "description": "write!(…)"
     },
     "writeln": {
         "prefix": "writeln",
         "body": [
-            "writeln!(${1}, \"${2:\\{${3::?}\\}}\")"
+            "writeln!(${1}, \"${2}\")"
         ],
         "description": "writeln!(…, …)"
     },

--- a/snippets/rust.json
+++ b/snippets/rust.json
@@ -128,14 +128,14 @@
     "format": {
         "prefix": "format",
         "body": [
-            "format!(\"${1:\\{${2::?}\\}}\")"
+            "format!(\"${1:{${2::?}}}\")"
         ],
         "description": "format!(…)"
     },
     "format_args": {
         "prefix": "format_args",
         "body": [
-            "format_args!(\"${1:\\{${2::?}\\}}\")"
+            "format_args!(\"${1:{${2::?}}}\")"
         ],
         "description": "format_args!(…)"
     },
@@ -184,7 +184,7 @@
     "panic": {
         "prefix": "panic",
         "body": [
-            "panic!(\"${1:\\{${2::?}\\}}\");"
+            "panic!(\"${1:{${2::?}}}\");"
         ],
         "description": "panic!(…);"
     },
@@ -198,7 +198,7 @@
     "println": {
         "prefix": "println",
         "body": [
-            "println!(\"${1:\\{${2::?}\\}}\");"
+            "println!(\"${1:{${2::?}}}\");"
         ],
         "description": "println!(…);"
     },


### PR DESCRIPTION
This commit removes an extra backslash being included with these snippets

 - panic
 - println
 - format
 - format_args

It seems braces are already escaped automatically.

Fixed #43