### PR TITLE
Added information about the "Rust Logging" output channel to the ISSUE.md file.

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -8,3 +8,14 @@ Output of the "Rust logging" channel:
 ```
 <place here>
 ```
+
+Remove everything below before submitting an issue.
+
+To see the "Rust logging" channel perform the following steps:
+
+* Click on the "View" menu item
+* Click on the "Output" menu item
+* The "Output" panel should open
+* There should be a select box to the right of the "Output" panel
+* Click on the select box
+* Choose "Rust Logging"


### PR DESCRIPTION
There was no information about it.
Some issuers asked where could they find it.