### PR TITLE
Clear diagnostics when new cargo command started

### DIFF
--- a/src/components/cargo/output_channel_task_manager.ts
+++ b/src/components/cargo/output_channel_task_manager.ts
@@ -83,6 +83,8 @@ export class OutputChannelTaskManager {
         this.runningTask.setStarted(() => {
             this.channel.clear();
             this.channel.append(`Started cargo ${args.join(' ')}\n\n`);
+
+            this.diagnosticPublisher.clearDiagnostics();
         });
 
         this.runningTask.setLineReceivedInStdout(line => {


### PR DESCRIPTION
Previous results remains and new results are not added when I run `Cargo: Build`. Perhaps `clearDiagnostics` call was missed in https://github.com/KalitaAlexey/vscode-rust/commit/cade0dedf25bd94b45e0619733fcf63a321bffa2