### PR TITLE
Removed "rust.formatOnSave".

### DIFF
--- a/doc/format.md
+++ b/doc/format.md
@@ -12,8 +12,6 @@ In order to format the document, make a right click and choose `"Format Document
 
 ## Format On Save
 
-The extension supports formatting the document opened in the active text editor on saving.
+Visual Studio Code supports formatting a document on saving.
 
-The `"rust.formatOnSave"` specifies whether the extension should format the active document on save.
-
-By default, it is `false`.
+Set `"editor.formatOnSave"` to `true` to make Visual Studio Code do that.

--- a/package.json
+++ b/package.json
@@ -227,11 +227,6 @@
           "default": false,
           "description": "Indicating whether any cargo command should be executed in an integrated terminal. Used only in not RLS mode"
         },
-        "rust.formatOnSave": {
-          "type": "boolean",
-          "default": false,
-          "description": "Turn on/off autoformatting file on save"
-        },
         "rust.actionOnSave": {
           "type": "string",
           "default": null,

--- a/src/components/configuration/configuration_manager.ts
+++ b/src/components/configuration/configuration_manager.ts
@@ -68,14 +68,6 @@ export class ConfigurationManager {
         return shouldShowRunningCargoTaskOutputChannel;
     }
 
-    public isFormatOnSaveEnabled(): boolean {
-        const configuration = ConfigurationManager.getConfiguration();
-
-        const isFormatOnSaveEnabled = configuration['formatOnSave'];
-
-        return isFormatOnSaveEnabled;
-    }
-
     public getCargoEnv(): any {
         const configuration = ConfigurationManager.getConfiguration();
 

--- a/src/components/formatting/formatting_manager.ts
+++ b/src/components/formatting/formatting_manager.ts
@@ -10,8 +10,7 @@ import {
     TextEdit,
     Uri,
     languages,
-    window,
-    workspace
+    window
 } from 'vscode';
 
 import { ConfigurationManager } from '../configuration/configuration_manager';

--- a/src/components/formatting/formatting_manager.ts
+++ b/src/components/formatting/formatting_manager.ts
@@ -40,28 +40,6 @@ export default class FormattingManager implements DocumentFormattingEditProvider
                 this
             )
         );
-
-        context.subscriptions.push(
-            workspace.onWillSaveTextDocument(event => {
-                const activeTextEditor = window.activeTextEditor;
-
-                if (!activeTextEditor) {
-                    return;
-                }
-
-                if (activeTextEditor.document !== event.document) {
-                    return;
-                }
-
-                const isFormatOnSaveEnabled = configurationManager.isFormatOnSaveEnabled();
-
-                if (!isFormatOnSaveEnabled) {
-                    return;
-                }
-
-                event.waitUntil(this.provideDocumentFormattingEdits(event.document));
-            })
-        );
     }
 
     public provideDocumentFormattingEdits(document: TextDocument): Thenable<TextEdit[]> {


### PR DESCRIPTION
Visual Studio Code supports "editor.formatOnSave".

It is a breaking change.
