### PR TITLE
Added a configuration parameter "actionOnStartingCommandIfThereIsRunningCommand"

### DIFF
--- a/doc/cargo_command_execution.md
+++ b/doc/cargo_command_execution.md
@@ -75,15 +75,15 @@ The possible values:
 * Some object (`{ "RUST_BACKTRACE": 1 }`)
 * `null`
 
-### Setting An Action To Handle Starting A New Command If There Is Another Running Command
+### Setting An Action To Handle Starting A New Command If There Is Another Command Running
 
-The `"rust.actionOnStartingCommandIfThereIsRunningCommand"` configuration parameter specifies what the extension should do in case of starting a new command if there is another running command.
+The `"rust.actionOnStartingCommandIfThereIsRunningCommand"` configuration parameter specifies what the extension should do in case of starting a new command if there is another command running.
 
 The possible values are:
 
 * `"Stop running command"` - the extension will stop another running command and start a new one
 * `"Ignore new command"` - the extension will ignore a request to start a new command
-* `"Show dialog to let me decide"` - the extension will show an information box to let a user decide whether another running command should be stopped
+* `"Show dialog to let me decide"` - the extension will show an information box to let the user decide whether or not to stop a running command
 
 
 ### Passing Arguments

--- a/doc/cargo_command_execution.md
+++ b/doc/cargo_command_execution.md
@@ -75,6 +75,17 @@ The possible values:
 * Some object (`{ "RUST_BACKTRACE": 1 }`)
 * `null`
 
+### Setting An Action To Handle Starting A New Command If There Is Another Running Command
+
+The `"rust.actionOnStartingCommandIfThereIsRunningCommand"` configuration parameter specifies what the extension should do in case of starting a new command if there is another running command.
+
+The possible values are:
+
+* `"Stop running command"` - the extension will stop another running command and start a new one
+* `"Ignore new command"` - the extension will ignore a request to start a new command
+* `"Show dialog to let me decide"` - the extension will show an information box to let a user decide whether another running command should be stopped
+
+
 ### Passing Arguments
 
 The extension supports several configuration parameters:

--- a/package.json
+++ b/package.json
@@ -228,11 +228,12 @@
           "description": "Indicating whether any cargo command should be executed in an integrated terminal. Used only in not RLS mode"
         },
         "rust.actionOnStartingCommandIfThereIsRunningCommand": {
-          "default": "stop",
+          "default": "Stop running command",
+          "type": "string",
           "enum": [
-            "stop",
-            "dialog",
-            null
+            "Stop running command",
+            "Ignore new command",
+            "Show dialog to let me decide"
           ]
         },
         "rust.actionOnSave": {

--- a/package.json
+++ b/package.json
@@ -227,6 +227,14 @@
           "default": false,
           "description": "Indicating whether any cargo command should be executed in an integrated terminal. Used only in not RLS mode"
         },
+        "rust.actionOnStartingCommandIfThereIsRunningCommand": {
+          "default": "stop",
+          "enum": [
+            "stop",
+            "dialog",
+            null
+          ]
+        },
         "rust.actionOnSave": {
           "type": "string",
           "default": null,

--- a/src/components/cargo/cargo_manager.ts
+++ b/src/components/cargo/cargo_manager.ts
@@ -11,6 +11,8 @@ import ChildLogger from '../logging/child_logger';
 
 import CustomConfigurationChooser from './custom_configuration_chooser';
 
+import { CommandStartHandleResult, Helper } from './helper';
+
 import { OutputChannelTaskManager } from './output_channel_task_manager';
 
 import { Task } from './task';
@@ -219,10 +221,20 @@ class CargoTaskManager {
             this.terminalTaskManager.execute(command, args, cwd);
         } else {
             if (this.outputChannelTaskManager.hasRunningTask()) {
-                if (force) {
-                    await this.outputChannelTaskManager.stopRunningTask();
-                } else {
+                if (!force) {
                     return;
+                }
+
+                const helper = new Helper(this.configurationManager);
+
+                const result = await helper.handleCommandStartWhenThereIsRunningCommand();
+
+                switch (result) {
+                    case CommandStartHandleResult.IgnoreNewCommand:
+                        return;
+
+                    case CommandStartHandleResult.StopRunningCommand:
+                        await this.outputChannelTaskManager.stopRunningTask();
                 }
             }
 

--- a/src/components/cargo/helper.ts
+++ b/src/components/cargo/helper.ts
@@ -1,0 +1,49 @@
+import { window } from 'vscode';
+
+import {
+    ActionOnStartingCommandIfThereIsRunningCommand,
+    ConfigurationManager
+} from '../configuration/configuration_manager';
+
+export enum CommandStartHandleResult {
+    StopRunningCommand,
+    IgnoreNewCommand
+}
+
+/**
+ * The class stores functionality which can't be placed somewhere else.
+ */
+export class Helper {
+    private configurationManager: ConfigurationManager;
+
+    public constructor(configurationManager: ConfigurationManager) {
+        this.configurationManager = configurationManager;
+    }
+
+    public handleCommandStartWhenThereIsRunningCommand(): Promise<CommandStartHandleResult> {
+        const action =
+            this.configurationManager.getActionOnStartingCommandIfThereIsRunningCommand();
+
+        switch (action) {
+            case ActionOnStartingCommandIfThereIsRunningCommand.ShowDialogToLetUserDecide:
+                return new Promise(async (resolve) => {
+                    const choice = await window.showInformationMessage(
+                        'You requested to start a command, but there is another running command',
+                        'Terminate'
+                    );
+
+                    if (choice === 'Terminate') {
+                        resolve(CommandStartHandleResult.StopRunningCommand);
+                    } else {
+                        resolve(CommandStartHandleResult.IgnoreNewCommand);
+                    }
+                });
+
+            case ActionOnStartingCommandIfThereIsRunningCommand.StopRunningCommand:
+                return Promise.resolve(CommandStartHandleResult.StopRunningCommand);
+
+            case ActionOnStartingCommandIfThereIsRunningCommand.IgnoreNewCommand:
+                return Promise.resolve(CommandStartHandleResult.IgnoreNewCommand);
+        }
+    }
+}

--- a/src/components/configuration/configuration_manager.ts
+++ b/src/components/configuration/configuration_manager.ts
@@ -17,8 +17,9 @@ export interface RlsConfiguration {
 }
 
 export enum ActionOnStartingCommandIfThereIsRunningCommand {
-    Stop,
-    Dialog
+    StopRunningCommand,
+    IgnoreNewCommand,
+    ShowDialogToLetUserDecide
 }
 
 export class ConfigurationManager {
@@ -117,21 +118,20 @@ export class ConfigurationManager {
         return this.rustSourcePath;
     }
 
-    public getActionOnStartingCommandIfThereIsRunningCommand():
-        ActionOnStartingCommandIfThereIsRunningCommand | undefined {
+    public getActionOnStartingCommandIfThereIsRunningCommand(): ActionOnStartingCommandIfThereIsRunningCommand {
         const configuration = ConfigurationManager.getConfiguration();
 
         const action = configuration['actionOnStartingCommandIfThereIsRunningCommand'];
 
         switch (action) {
-            case 'stop':
-                return ActionOnStartingCommandIfThereIsRunningCommand.Stop;
+            case 'Stop running command':
+                return ActionOnStartingCommandIfThereIsRunningCommand.StopRunningCommand;
 
-            case 'dialog':
-                return ActionOnStartingCommandIfThereIsRunningCommand.Dialog;
+            case 'Show dialog to let me decide':
+                return ActionOnStartingCommandIfThereIsRunningCommand.ShowDialogToLetUserDecide;
 
             default:
-                return undefined;
+                return ActionOnStartingCommandIfThereIsRunningCommand.IgnoreNewCommand;
         }
     }
 

--- a/src/components/configuration/configuration_manager.ts
+++ b/src/components/configuration/configuration_manager.ts
@@ -16,6 +16,11 @@ export interface RlsConfiguration {
     env?: any;
 }
 
+export enum ActionOnStartingCommandIfThereIsRunningCommand {
+    Stop,
+    Dialog
+}
+
 export class ConfigurationManager {
     private rustcSysRoot: string | undefined;
 
@@ -110,6 +115,24 @@ export class ConfigurationManager {
 
     public getRustSourcePath(): string | undefined {
         return this.rustSourcePath;
+    }
+
+    public getActionOnStartingCommandIfThereIsRunningCommand():
+        ActionOnStartingCommandIfThereIsRunningCommand | undefined {
+        const configuration = ConfigurationManager.getConfiguration();
+
+        const action = configuration['actionOnStartingCommandIfThereIsRunningCommand'];
+
+        switch (action) {
+            case 'stop':
+                return ActionOnStartingCommandIfThereIsRunningCommand.Stop;
+
+            case 'dialog':
+                return ActionOnStartingCommandIfThereIsRunningCommand.Dialog;
+
+            default:
+                return undefined;
+        }
     }
 
     public static getConfiguration(): WorkspaceConfiguration {


### PR DESCRIPTION
It is preliminary pull request. It is not finished.

I am going to add handling the configuration parameter.

If it is set to `"stop"`, the extension will stop the running command and start a new one.

If it is set to `"dialog"`, the extension will show a message dialog with the *"There is a running cargo command"* text and the two buttons *"Terminate"* and *"Cancel"*.
If a user chooses `"Terminate"`, the extension will stop the running command and start the new one.
Otherwise, the extension will ignore a request to start a new command.

If it is set to `null`, the extension will ignore a request to start a new command.

Another name for the configuration parameter is welcome.

Fixes #75