### PR TITLE
Made creating of a terminal preserve focus.

### DIFF
--- a/src/components/cargo/terminal_task_manager.ts
+++ b/src/components/cargo/terminal_task_manager.ts
@@ -75,6 +75,6 @@ export class TerminalTaskManager {
         // Start a requested command
         this.runningTerminal.sendText(`${cargoPath} ${command} ${args.join(' ')}`);
 
-        this.runningTerminal.show();
+        this.runningTerminal.show(true);
     }
 }


### PR DESCRIPTION
Currently the focus is missed after creating of a terminal.
It wasn't intended.
It isn't consistent with creating of a task in the output channel.