### PR TITLE
Fixed diagnostics

### DIFF
--- a/src/components/cargo/diagnostic_parser.ts
+++ b/src/components/cargo/diagnostic_parser.ts
@@ -115,7 +115,11 @@ export class DiagnosticParser {
             message = `${compilerMessage.code.code}: ${message}`;
         }
 
-        this.addNotesToMessage(message, compilerMessage.children, 1);
+        if (primarySpan.label) {
+            message += `\n  label: ${primarySpan.label}`;
+        }
+
+        message = this.addNotesToMessage(message, compilerMessage.children, 1);
 
         const diagnostic = new Diagnostic(range, message, this.toSeverity(compilerMessage.level));
 
@@ -141,10 +145,10 @@ export class DiagnosticParser {
     }
 
     private addNotesToMessage(msg: string, children: any[], level: number): string {
-        const ident = '   '.repeat(level);
+        const indentation = '  '.repeat(level);
 
         for (const child of children) {
-            msg += `\n${ident}${child.message}`;
+            msg += `\n${indentation}${child.level}: ${child.message}`;
 
             if (child.spans && child.spans.length > 0) {
                 msg += ': ';


### PR DESCRIPTION
For the code:
```rust
struct Foo {}

fn bar(foo: Foo) {}

fn main() {
    let foo = Foo {};
    bar(foo);
    bar(foo);
}
```

It gave:
```
E0382: use of moved value: `foo`
```

Now it gives:
```
E0382: use of moved value: `foo`
  label: value used here after move
  note: move occurs because `foo` has type `Foo`, which does not implement the `Copy` trait
```


Fixes #81 