### PR TITLE
Use rustfmt for document formatting in RLS mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -499,6 +499,11 @@
                 "never"
               ],
               "type": "string"
+            },
+            "useRustfmtForFormatting": {
+              "default": false,
+              "description": "Use rustfmt for formatting instead of RLS",
+              "type": "boolean"
             }
           }
         }

--- a/src/components/configuration/Configuration.ts
+++ b/src/components/configuration/Configuration.ts
@@ -17,11 +17,11 @@ import { Rustup } from './Rustup';
 import { NotRustup } from './NotRustup';
 
 export interface RlsConfiguration {
+    executable?: string;
     args?: string[];
-
     env?: any;
-
-    revealOutputChannelOn: RevealOutputChannelOn;
+    revealOutputChannelOn?: string; // RevealOutputChannelOn;
+    useRustfmtForFormatting?: boolean;
 }
 
 export enum ActionOnStartingCommandIfThereIsRunningCommand {
@@ -196,11 +196,11 @@ export class Configuration {
      */
     public getRlsArgs(): string[] {
         const getRlsArgsSpecifiedByUser = () => {
-            const rlsConfiguration: any = this.getRlsConfiguration();
+            const rlsConfiguration = this.getRlsConfiguration();
             if (!rlsConfiguration) {
                 return undefined;
             }
-            const rlsArgsSpecifiedByUser: any = rlsConfiguration.args;
+            const rlsArgsSpecifiedByUser = rlsConfiguration.args;
             if (!rlsArgsSpecifiedByUser) {
                 return undefined;
             }
@@ -219,7 +219,7 @@ export class Configuration {
      */
     public getRlsEnv(): object {
         const getRlsEnvSpecifiedByUser = () => {
-            const rlsConfiguration: any = this.getRlsConfiguration();
+            const rlsConfiguration = this.getRlsConfiguration();
             if (!rlsConfiguration) {
                 return undefined;
             }
@@ -243,7 +243,7 @@ export class Configuration {
      * * A default value which is on error
      */
     public getRlsRevealOutputChannelOn(): RevealOutputChannelOn {
-        const rlsConfiguration: any | undefined = this.getRlsConfiguration();
+        const rlsConfiguration = this.getRlsConfiguration();
 
         const defaultValue = RevealOutputChannelOn.Error;
 
@@ -269,6 +269,18 @@ export class Configuration {
             default:
                 return defaultValue;
         }
+    }
+
+    public getUseRustfmtForFormatting(): boolean {
+        const rlsConfiguration = this.getRlsConfiguration();
+
+        const defaultValue = false;
+
+        if (!rlsConfiguration) {
+            return defaultValue;
+        }
+
+        return rlsConfiguration.useRustfmtForFormatting || defaultValue;
     }
 
     public shouldExecuteCargoCommandInTerminal(): boolean {
@@ -497,10 +509,10 @@ export class Configuration {
         this.racerPath = pathToRacer;
     }
 
-    private getRlsConfiguration(): any | undefined {
+    private getRlsConfiguration(): RlsConfiguration | undefined {
         const configuration = Configuration.getConfiguration();
 
-        const rlsConfiguration: any = configuration['rls'];
+        const rlsConfiguration: RlsConfiguration = configuration['rls'];
 
         return rlsConfiguration;
     }

--- a/src/components/language_client/manager.ts
+++ b/src/components/language_client/manager.ts
@@ -1,3 +1,5 @@
+import * as vscode from 'vscode';
+
 import { Disposable, ExtensionContext, window, workspace } from 'vscode';
 
 import { LanguageClient, RevealOutputChannelOn, State } from 'vscode-languageclient';
@@ -8,6 +10,10 @@ import { Creator as LanguageClientCreator } from './creator';
 
 import { StatusBarItem } from './status_bar_item';
 
+import FormattingManager from '../formatting/formatting_manager';
+
+import { Configuration } from '../configuration/Configuration';
+
 export class Manager {
     private languageClientCreator: LanguageClientCreator;
 
@@ -17,13 +23,26 @@ export class Manager {
 
     private logger: ChildLogger;
 
-    public constructor(
-        context: ExtensionContext,
+    public static async create(context: ExtensionContext,
+        configuration: Configuration,
         logger: ChildLogger,
         executable: string,
         args: string[] | undefined,
         env: any | undefined,
         revealOutputChannelOn: RevealOutputChannelOn
+    ): Promise<Manager> {
+        const formattingManager: FormattingManager | undefined = await FormattingManager.create(context, configuration);
+        return new Manager(context, logger, executable, args, env, revealOutputChannelOn, formattingManager);
+    }
+
+    private constructor(
+        context: ExtensionContext,
+        logger: ChildLogger,
+        executable: string,
+        args: string[] | undefined,
+        env: any | undefined,
+        revealOutputChannelOn: RevealOutputChannelOn,
+        formattingManager: FormattingManager | undefined
     ) {
         this.languageClientCreator = new LanguageClientCreator(
             executable,
@@ -50,6 +69,10 @@ export class Manager {
         context.subscriptions.push(new Disposable(() => {
             this.stop();
         }));
+
+        if (formattingManager) {
+            vscode.languages.registerDocumentFormattingEditProvider('rust', formattingManager);
+        }
     }
 
     /**

--- a/src/components/language_client/manager.ts
+++ b/src/components/language_client/manager.ts
@@ -31,8 +31,20 @@ export class Manager {
         env: any | undefined,
         revealOutputChannelOn: RevealOutputChannelOn
     ): Promise<Manager> {
-        const formattingManager: FormattingManager | undefined = await FormattingManager.create(context, configuration);
+        let formattingManager: FormattingManager | undefined;
+        if (configuration.getUseRustfmtForFormatting()) {
+            formattingManager = await FormattingManager.create(context, configuration);
+        }
         return new Manager(context, logger, executable, args, env, revealOutputChannelOn, formattingManager);
+    }
+
+    /**
+     * Starts the language client at first time
+     */
+    public initialStart(): void {
+        this.start();
+
+        this.statusBarItem.show();
     }
 
     private constructor(
@@ -73,15 +85,6 @@ export class Manager {
         if (formattingManager) {
             vscode.languages.registerDocumentFormattingEditProvider('rust', formattingManager);
         }
-    }
-
-    /**
-     * Starts the language client at first time
-     */
-    public initialStart(): void {
-        this.start();
-
-        this.statusBarItem.show();
     }
 
     private start(): void {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -148,12 +148,12 @@ export async function activate(ctx: ExtensionContext): Promise<void> {
  * @param configuration A configuration
  * @param pathToRlsExecutable A path to the executable of RLS
  */
-function runInRlsMode(
+async function runInRlsMode(
     context: ExtensionContext,
     logger: RootLogger,
     configuration: Configuration,
     rlsPath: string
-): void {
+): Promise<void> {
     const functionLogger = logger.createChildLogger('runInRlsMode: ');
     functionLogger.debug(`rlsPath=${rlsPath}`);
     const env = configuration.getRlsEnv();
@@ -162,8 +162,9 @@ function runInRlsMode(
     functionLogger.debug(`args=${JSON.stringify(args)}`);
     const revealOutputChannelOn = configuration.getRlsRevealOutputChannelOn();
     functionLogger.debug(`revealOutputChannelOn=${revealOutputChannelOn}`);
-    const languageClientManager = new LanguageClientManager(
+    const languageClientManager = await LanguageClientManager.create(
         context,
+        configuration,
         logger.createChildLogger('Language Client Manager: '),
         rlsPath,
         args,
@@ -193,7 +194,7 @@ async function chooseModeAndRun(
         await legacyModeManager.start();
     } else {
         configuration.setMode(Mode.RLS);
-        runInRlsMode(context, logger, configuration, <string>rls);
+        await runInRlsMode(context, logger, configuration, <string>rls);
     }
 }
 


### PR DESCRIPTION
fixes #223

According to https://code.visualstudio.com/blogs/2016/11/15/formatters-best-practices#_the-formatting-api you can just overwrite formatting provider.

Tested on gentoo with `vscode-1.12.2` and `rustfmt-0.6.3`