### PR TITLE
config: Do not treat RLS as a special case for running cargo in terminal

### DIFF
--- a/src/components/configuration/Configuration.ts
+++ b/src/components/configuration/Configuration.ts
@@ -179,10 +179,6 @@ export class Configuration {
     }
 
     public shouldExecuteCargoCommandInTerminal(): boolean {
-        // When RLS is used any cargo command is executed in an integrated terminal.
-        if (this.mode() === Mode.RLS) {
-            return true;
-        }
         const configuration = Configuration.getConfiguration();
         const shouldExecuteCargoCommandInTerminal = configuration['executeCargoCommandInTerminal'];
         return shouldExecuteCargoCommandInTerminal;


### PR DESCRIPTION
Fixes #283

I used to compile my own extension from the sources with that modification in order to be able to not run cargo in terminal using RLS.

I think it makes sense not to treat RLS as a special case here and use the configuration option as intended (with `rust.executeCargoCommandInTerminal`).