### PR TITLE
Update RLS component name

### DIFF
--- a/src/components/configuration/Rustup.ts
+++ b/src/components/configuration/Rustup.ts
@@ -377,7 +377,7 @@ export class Rustup {
      * Returns the name of the component RLS
      */
     private static getRlsComponentName(): string {
-        return 'rls';
+        return 'rls-preview';
     }
 
     /**


### PR DESCRIPTION
This is fix for issue #369

Description:
Component `rls` renamed to `rls-preview` so extension works as expected